### PR TITLE
read response byte wise, to avoid timeout problems

### DIFF
--- a/Net/HL7/Connection.php
+++ b/Net/HL7/Connection.php
@@ -107,10 +107,10 @@ class Net_HL7_Connection {
 
         $data = "";
 
-        while(($buf = $handle->read(256)) !== false) {
+        while(($buf = $handle->read(1)) !== false) {
             $data .= $buf;
 
-            if(preg_match("/" . $this->_MESSAGE_SUFFIX . "$/", $buf))
+            if(preg_match("/" . $this->_MESSAGE_SUFFIX . "$/", $data))
                 break;
         }
 


### PR DESCRIPTION
This fixes issue #2 
The response is now read byte wise from the file pointer.
I don't think, this causes a noticable performance hit, because HL7 messages tend to be small.
